### PR TITLE
Work/generate thumbnail

### DIFF
--- a/backend/database/images.py
+++ b/backend/database/images.py
@@ -92,14 +92,14 @@ class ImageModel(DynamicDocument):
         AnnotationModel.objects(image_id=self.id).delete()
         return super(ImageModel, self).delete(*args, **kwargs)
 
-    def thumbnail(self):
+    def thumbnail(self, regen=False):
         """
         Generates (if required) and returns thumbnail
         """
         
         thumbnail_path = self.thumbnail_path()
 
-        if self.regenerate_thumbnail or \
+        if self.regenerate_thumbnail or regen or \
             not os.path.isfile(thumbnail_path):
             
             # logger.debug(f'Generating thumbnail for {self.id}')

--- a/backend/workers/tasks/data.py
+++ b/backend/workers/tasks/data.py
@@ -192,11 +192,11 @@ def import_annotations(task_id, dataset_id, coco_json):
     task.info("===== Loading Images =====")
     # image id mapping ( file: database )
     images_id = {}
+    image_maps = {}
     categories_by_image = {}
 
     # Find all images
     for image in coco_images:
-        image_id = image.get('id')
         image_filename = image.get('file_name')
 
         # update progress
@@ -216,13 +216,15 @@ def import_annotations(task_id, dataset_id, coco_json):
 
         task.info(f"Image {image_filename} found")
         image_model = image_model[0]
+        image_id = image_model.id
+        image_maps[image.get('id')] = image_id
         images_id[image_id] = image_model
         categories_by_image[image_id] = list()
 
     task.info("===== Import Annotations =====")
     for annotation in coco_annotations:
 
-        image_id = annotation.get('image_id')
+        image_id = image_maps[annotation.get('image_id')]
         category_id = annotation.get('category_id')
         segmentation = annotation.get('segmentation', [])
         keypoints = annotation.get('keypoints', [])

--- a/backend/workers/tasks/data.py
+++ b/backend/workers/tasks/data.py
@@ -285,6 +285,7 @@ def import_annotations(task_id, dataset_id, coco_json):
             task.info(
                 f"Annotation already exists (i:{image_id}, c:{category_id})")
 
+    task.info("===== Create Thumbnails =====")
     for image_id in images_id:
         image_model = images_id[image_id]
         category_ids = categories_by_image[image_id]
@@ -302,6 +303,7 @@ def import_annotations(task_id, dataset_id, coco_json):
             set__num_annotations=num_annotations
         )
         image_model.thumbnail(regen=True)
+        task.info(image_id)
 
     task.set_progress(100, socket=socket)
 

--- a/backend/workers/tasks/data.py
+++ b/backend/workers/tasks/data.py
@@ -299,6 +299,7 @@ def import_annotations(task_id, dataset_id, coco_json):
             set__category_ids=list(set(all_category_ids)),
             set__num_annotations=num_annotations
         )
+        image_model.thumbnail(regen=True)
 
     task.set_progress(100, socket=socket)
 


### PR DESCRIPTION
## 背景

事前推論済みのcocoファイルをインポートしたときにサムネイル画像が自動で生成されるようにしたい。

## 変更内容

- workers/data.py: import_annotationsのタスクにサムネイル生成を追加
- サムネイル生成用の制御変数を一つ追加
- cocoファイルインポートのバグを修正

## 相談・メモ
- あとでpre-annotater側の修正も必要

## 動作確認
- 目視で動作チェック
