### PR TITLE
カテゴリを変更するショートカットキーを追加

### DIFF
--- a/client/src/mixins/shortcuts.js
+++ b/client/src/mixins/shortcuts.js
@@ -87,6 +87,101 @@ export default {
           function: this.previousImage
         },
         {
+          default: ["0"],
+          name: "Change Category to 0",
+          function: () => {
+            let current = this.currentAnnotation
+            if (current.annotation) {
+              this.updateAnnotationCategory(current.annotation, current.$parent.category, "0")
+            }
+          }
+        },
+        {
+          default: ["1"],
+          name: "Change Category to 1",
+          function: () => {
+            let current = this.currentAnnotation
+            if (current.annotation) {
+              this.updateAnnotationCategory(current.annotation, current.$parent.category, "1")
+            }
+          }
+        },
+        {
+          default: ["2"],
+          name: "Change Category to 2",
+          function: () => {
+            let current = this.currentAnnotation
+            if (current.annotation) {
+              this.updateAnnotationCategory(current.annotation, current.$parent.category, "2")
+            }
+          }
+        },
+        {
+          default: ["3"],
+          name: "Change Category to 3",
+          function: () => {
+            let current = this.currentAnnotation
+            if (current.annotation) {
+              this.updateAnnotationCategory(current.annotation, current.$parent.category, "3")
+            }
+          }
+        },
+        {
+          default: ["4"],
+          name: "Change Category to 4",
+          function: () => {
+            let current = this.currentAnnotation
+            if (current.annotation) {
+              this.updateAnnotationCategory(current.annotation, current.$parent.category, "4")
+            }
+          }
+        },{
+          default: ["5"],
+          name: "Change Category to 5",
+          function: () => {
+            let current = this.currentAnnotation
+            if (current.annotation) {
+              this.updateAnnotationCategory(current.annotation, current.$parent.category, "5")
+            }
+          }
+        },{
+          default: ["6"],
+          name: "Change Category to 6",
+          function: () => {
+            let current = this.currentAnnotation
+            if (current.annotation) {
+              this.updateAnnotationCategory(current.annotation, current.$parent.category, "6")
+            }
+          }
+        },{
+          default: ["7"],
+          name: "Change Category to 7",
+          function: () => {
+            let current = this.currentAnnotation
+            if (current.annotation) {
+              this.updateAnnotationCategory(current.annotation, current.$parent.category, "7")
+            }
+          }
+        },{
+          default: ["8"],
+          name: "Change Category to 8",
+          function: () => {
+            let current = this.currentAnnotation
+            if (current.annotation) {
+              this.updateAnnotationCategory(current.annotation, current.$parent.category, "8")
+            }
+          }
+        },{
+          default: ["9"],
+          name: "Change Category to 9",
+          function: () => {
+            let current = this.currentAnnotation
+            if (current.annotation) {
+              this.updateAnnotationCategory(current.annotation, current.$parent.category, "9")
+            }
+          }
+        },
+        {
           default: ["v"],
           name: "Polygon Tool",
           function: () => {


### PR DESCRIPTION
## 背景
アノテーション操作を短時間でできるようにしたい

## 変更内容
- カテゴリ変更時のショートカットキーを追加
  - カテゴリは全部で0〜9ある想定にしており、"0"〜"9"のキーを押すことでカテゴリを変更できるようにした
- これ以外のコマンドはすでに便利なのが用意されているのでそのまま利用

## 相談・メモ

## 動作確認
- OK
