### PR TITLE
Feature/complete dataset button

### DIFF
--- a/backend/database/datasets.py
+++ b/backend/database/datasets.py
@@ -26,6 +26,8 @@ class DatasetModel(DynamicDocument):
     deleted = BooleanField(default=False)
     deleted_date = DateTimeField()
 
+    completed = BooleanField(default=False)
+
     def save(self, *args, **kwargs):
 
         directory = os.path.join(Config.DATASET_DIRECTORY, self.name + '/')

--- a/backend/database/datasets.py
+++ b/backend/database/datasets.py
@@ -27,6 +27,7 @@ class DatasetModel(DynamicDocument):
     deleted_date = DateTimeField()
 
     completed = BooleanField(default=False)
+    completed_date = DateTimeField()
 
     def save(self, *args, **kwargs):
 

--- a/backend/database/datasets.py
+++ b/backend/database/datasets.py
@@ -27,7 +27,7 @@ class DatasetModel(DynamicDocument):
     deleted_date = DateTimeField()
 
     completed = BooleanField(default=False)
-    completed_date = DateTimeField()
+    completed_date = DateTimeField(null=True)
 
     def save(self, *args, **kwargs):
 

--- a/backend/webserver/api/datasets.py
+++ b/backend/webserver/api/datasets.py
@@ -299,7 +299,7 @@ class DatasetData(Resource):
         page = args['page']
         folder = args['folder']
 
-        datasets = current_user.datasets.filter(deleted=False)
+        datasets = current_user.datasets.filter(deleted=False, completed=False)
         pagination = Pagination(datasets.count(), limit, page)
         datasets = datasets[pagination.start:pagination.end]
 
@@ -586,3 +586,19 @@ class DatasetScan(Resource):
         
         return dataset.scan()
 
+
+@api.route('/<int:dataset_id>/complete')
+class DatasetComplete(Resource):
+
+    @login_required
+    def post(self, dataset_id):
+
+        """ Set complete flag dataset by ID """
+
+        dataset = current_user.datasets.filter(id=dataset_id, deleted=False).first()
+        if dataset is None:
+            return {"message": "Invalid dataset id"}, 400
+
+        dataset.update(completed=True)
+
+        return {"success": True}

--- a/backend/webserver/api/datasets.py
+++ b/backend/webserver/api/datasets.py
@@ -593,7 +593,7 @@ class DatasetComplete(Resource):
     @login_required
     def post(self, dataset_id):
 
-        """ Set complete flag dataset by ID """
+        """ Set complete flag by dataset ID"""
 
         dataset = current_user.datasets.filter(id=dataset_id, deleted=False).first()
         if dataset is None:
@@ -602,3 +602,21 @@ class DatasetComplete(Resource):
         dataset.update(completed=True)
 
         return {"success": True}
+
+
+@api.route('/<int:dataset_id>/incomplete')
+class DatasetComplete(Resource):
+
+    @login_required
+    def post(self, dataset_id):
+
+        """ Set complete flag to false by dataset ID """
+
+        dataset = current_user.datasets.filter(id=dataset_id, deleted=False).first()
+        if dataset is None:
+            return {"message": "Invalid dataset id"}, 400
+
+        dataset.update(completed=False)
+
+        return {"success": True}
+

--- a/backend/webserver/api/datasets.py
+++ b/backend/webserver/api/datasets.py
@@ -599,7 +599,7 @@ class DatasetComplete(Resource):
         if dataset is None:
             return {"message": "Invalid dataset id"}, 400
 
-        dataset.update(completed=True)
+        dataset.update(completed=True, set__completed_date=datetime.datetime.now())
 
         return {"success": True}
 

--- a/backend/webserver/api/datasets.py
+++ b/backend/webserver/api/datasets.py
@@ -599,7 +599,7 @@ class DatasetComplete(Resource):
         if dataset is None:
             return {"message": "Invalid dataset id"}, 400
 
-        dataset.update(completed=True, set__completed_date=datetime.datetime.now())
+        dataset.update(completed=True, completed_date=datetime.datetime.now())
 
         return {"success": True}
 
@@ -620,3 +620,19 @@ class DatasetComplete(Resource):
 
         return {"success": True}
 
+
+@api.route('/incomplete/last')
+class DatasetComplete(Resource):
+
+    @login_required
+    def post(self):
+
+        """ Set complete flag to false by dataset ID """
+
+        dataset = current_user.datasets.order_by('-completed_date').limit(1).first()
+        if dataset is None:
+            return {"message": "Invalid dataset id"}, 400
+
+        dataset.update(completed=False, completed_date=None)
+
+        return {"success": True}

--- a/backend/webserver/api/datasets.py
+++ b/backend/webserver/api/datasets.py
@@ -587,7 +587,7 @@ class DatasetScan(Resource):
         return dataset.scan()
 
 
-@api.route('/<int:dataset_id>/complete')
+@api.route('/complete/<int:dataset_id>')
 class DatasetComplete(Resource):
 
     @login_required
@@ -604,7 +604,7 @@ class DatasetComplete(Resource):
         return {"success": True}
 
 
-@api.route('/<int:dataset_id>/incomplete')
+@api.route('/incomplete/<int:dataset_id>')
 class DatasetComplete(Resource):
 
     @login_required

--- a/client/src/components/cards/DatasetCard.vue
+++ b/client/src/components/cards/DatasetCard.vue
@@ -266,7 +266,7 @@ export default {
     },
     onCompleteClick() {
       axios
-        .post("/api/dataset/" + this.dataset.id + "/complete")
+        .post("/api/dataset/complete/" + this.dataset.id)
         .then(() => {
           this.$parent.updatePage();
         })

--- a/client/src/components/cards/DatasetCard.vue
+++ b/client/src/components/cards/DatasetCard.vue
@@ -81,6 +81,12 @@
           >
             Download COCO
           </button>
+          <button
+            class="dropdown-item"
+            @click="onCompleteClick"
+          >
+            Complete
+          </button>
           <hr v-show="dataset.permissions.delete" />
           <button
             class="dropdown-item delete"
@@ -256,6 +262,16 @@ export default {
         })
         .then(() => {
           this.$parent.updatePage();
+        });
+    },
+    onCompleteClick() {
+      axios
+        .post("/api/dataset/" + this.dataset.id + "/complete")
+        .then(() => {
+          this.$parent.updatePage();
+        })
+        .catch(err => {
+          console.log(err)
         });
     },
     onCocoDownloadClick() {

--- a/client/src/views/Datasets.vue
+++ b/client/src/views/Datasets.vue
@@ -43,6 +43,13 @@
             >
               Refresh
             </button>
+            <button
+              type="button"
+              class="btn btn-incomplete"
+              @click="incompleteDataset()"
+            >
+              Incomplete
+            </button>
           </div>
         </div>
 
@@ -182,6 +189,7 @@
 </template>
 
 <script>
+import axios from "axios";
 import toastrs from "@/mixins/toastrs";
 import Datasets from "@/models/datasets";
 import AdminPanel from "@/models/admin";
@@ -254,6 +262,16 @@ export default {
             error.response.data.message
           );
         });
+    },
+    incompleteDataset() {
+      axios
+        .post("/api/dataset/incomplete/last")
+        .then(() => {
+          this.updatePage();
+        })
+        .catch(err => {
+          console.log(err)
+        });
     }
   },
   watch: {
@@ -292,5 +310,9 @@ export default {
   color: darkblue;
   font-size: 20px;
   display: inline;
+}
+.btn-incomplete {
+  color: white;
+  background: orange;
 }
 </style>


### PR DESCRIPTION
## 背景

アノテーション完了したデータセットは、データセット一覧画面で表示されないようにしたい。

## 変更内容
- Database/datasetModelにアノテーション完了確認用にcompletedカラムを追加
- サーバ：アノテーション完了APIを作成、データセット取得APIでcompletedを見るよう変更
- クライアント：アノテーション完了ボタンを追加

## 相談・メモ

## 動作確認
手動で確認ずみ
