### PR TITLE
Feature/batch import datasets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 datasets/*
+cocos/*
 models/*

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .idea/*
 datasets/*
 !datasets/.gitkeep
+cocos/*
+!cocos/.gitkeep
 .history/*
 .vscode/*
 __pycache__

--- a/backend/webserver/api/datasets.py
+++ b/backend/webserver/api/datasets.py
@@ -100,8 +100,11 @@ class Datasets(Resource):
         if not current_user.is_admin:
             return {"success": False, "message": "Access denied"}, 401
 
-        categories = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
-        category_ids = CategoryModel.bulk_create(categories)
+        categories = current_user.categories.filter(deleted=False).all()
+        category_names = []
+        for c in categories:
+            category_names.append(c.name)
+        category_ids = CategoryModel.bulk_create(category_names)
 
         dataset_path = os.getenv("DATASET_DIRECTORY", "/datasets/")
 
@@ -163,7 +166,7 @@ class Datasets(Resource):
             return {"success": False, "message": "Access denied"}, 401
 
         dataset_path = os.getenv("DATASET_DIRECTORY", "/datasets/")
-        coco_path = "/cocos/"
+        coco_path = os.getenv("COCOFILES_DIRECTORY", "/cocos/")
 
         dirs = []
         for f in os.listdir(dataset_path):

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -23,6 +23,7 @@ services:
       - NAME=Test Annotator
     volumes:
       - "./datasets:/datasets"
+      - "./cocos:/cocos"
       - "./models:/models"
     depends_on:
       - database
@@ -40,6 +41,7 @@ services:
       - "./backend/workers:/workspace/workers"
       - "./backend/database:/workspace/database"
       - "./datasets:/datasets"
+      - "./cocos:/cocos"
     depends_on:
       - messageq
       - database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - FILE_WATCHER=true
     volumes:
       - "./datasets:/datasets"
+      - "./cocos:/cocos"
       - "./models:/models"
     depends_on:
       - database
@@ -30,6 +31,7 @@ services:
     image: jsbroks/coco-annotator:workers-stable
     volumes:
       - "./datasets:/datasets"
+      - "./cocos:/cocos"
     depends_on:
       - messageq
       - database


### PR DESCRIPTION
## 背景
アノテーションツールにデータセット登録を一括で行えるようにしたい
現状は「登録」「スキャン」「cocoインポート」をそれぞれのデータセットに対して手動でやっている

## 変更内容
- 一括登録用のAPIを作成した（3つのapi）
- cocoファイル配置用のディレクトリを用意した

## 相談・メモ
「登録」「スキャン」「cocoインポート」はそれぞれタスクキューの仕組みで非同期実行されるが、これらの実行順序が入れ替わると困る。

優先度付けも可能ではあるが、エラーなどで順序が入れ替わる可能性もあり、厳密性を持たせることが難しそうだったため、ひとまず簡単に「登録」「スキャン」「cocoインポート」の一括操作を別々のAPIで実装した。時間を置いてから順序次の操作をやるようなフローになる。

※一括登録したデータセットを各ユーザに振り分ける実装はまだ

## 動作確認
- ローカルで確認
- ただし本番と同じ規模のデータセットで実際に一括登録を行なっているわけではないため、負荷の影響までは確認できてない
